### PR TITLE
Lowering deployment target to iOS 9.0

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 				DEVELOPMENT_TEAM = R7Z6749JJ5;
 				FRAMEWORK_SEARCH_PATHS = ../Carthage/Build/iOS;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.RxStateFlow.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -569,6 +570,7 @@
 				DEVELOPMENT_TEAM = R7Z6749JJ5;
 				FRAMEWORK_SEARCH_PATHS = ../Carthage/Build/iOS;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.RxStateFlow.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ struct LoggingMiddleware: Middleware {
 
 ## Requirements
 
-* iOS 10.0+
+* iOS 9.0+
 * Xcode 8.1+
 * Swift 3
 

--- a/RxStateFlow.podspec
+++ b/RxStateFlow.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Miroslav Valkovic-Madjer" => "miro.madjer@gmail.com" }
   s.social_media_url   = "http://twitter.com/miromadjer"
-  s.platform     = :ios, "10.0"
-  s.ios.deployment_target = "10.0"
+  s.platform     = :ios, "9.0"
+  s.ios.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/mmadjer/RxStateFlow.git", tag: s.version.to_s }
   s.source_files = 'Sources/**/*.{swift}'
   s.requires_arc = true

--- a/RxStateFlow.xcodeproj/project.pbxproj
+++ b/RxStateFlow.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.RxStateFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -464,6 +465,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.RxStateFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
I was curious why the deployment target was set to 10.0. I tested the Example app on an iOS 9.0 simulator and everything seemed to work.

If you have difficulties compiling with Carthage, you may need to update dependencies.

My `Cartfile.resolved` that worked:
```
github "ReactiveX/RxSwift" "3.3.1"
github "realm/realm-cocoa" "v2.4.4"
github "RxSwiftCommunity/RxRealm" "0.5.2"
```